### PR TITLE
TRANSACTION PAGE CARD QUANTITY REMOVE

### DIFF
--- a/src/app/(secured)/(admin)/admin/users-orders/_components/TransactionBoard.tsx
+++ b/src/app/(secured)/(admin)/admin/users-orders/_components/TransactionBoard.tsx
@@ -341,13 +341,10 @@ export default function TransactionDashboard({
                               <p className="text-sm text-gray-500 truncate">
                                 ID: {card.id}
                               </p>
-                              <p className="text-sm">
-                                Quantity: {card.quantity}
-                              </p>
                               <Button
                                 variant="outline"
                                 size="sm"
-                                className="mt-2 w-full sm:w-auto"
+                                className="mt-8 w-full sm:w-auto"
                                 onClick={() => {
                                   setSelectedTransaction(transaction);
                                   setSelectedCardIndex(index);
@@ -487,12 +484,6 @@ export default function TransactionDashboard({
               <div className="flex justify-between">
                 <span className="font-medium">Name:</span>
                 <span>{selectedTransaction.cards[selectedCardIndex].name}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="font-medium">Quantity:</span>
-                <span>
-                  {selectedTransaction.cards[selectedCardIndex].quantity}
-                </span>
               </div>
               <Separator />
               <div className="flex justify-between">


### PR DESCRIPTION
Refactored the transactions page to remove the redundant `quantity` from cards and dialog.
Includes updated screenshots of both components.

**Card**
![image](https://github.com/user-attachments/assets/602503b0-73b5-42d3-8bff-f4f4377eafac)

**Dialog**
![image](https://github.com/user-attachments/assets/87920692-7bff-4f9e-baf2-7464d1cf1d02)
