### PR TITLE
Add subscription id and transfer code columns

### DIFF
--- a/src/app/(secured)/(admin)/admin/print-cards/_components/PrintCardsTable.tsx
+++ b/src/app/(secured)/(admin)/admin/print-cards/_components/PrintCardsTable.tsx
@@ -168,6 +168,8 @@ const PrintCardsTable = ({ cardsData }: { cardsData: PrintCardsInfo[] }) => {
             <TableRow>
               <TableHead>Customer Name</TableHead>
               <TableHead>Transaction ID</TableHead>
+              <TableHead>Subscription ID</TableHead>
+              <TableHead>Transfer Code</TableHead>
               <TableHead>Date Created</TableHead>
               <TableHead>Status</TableHead>
               <TableHead className="w-[100px] text-center">Actions</TableHead>
@@ -179,6 +181,8 @@ const PrintCardsTable = ({ cardsData }: { cardsData: PrintCardsInfo[] }) => {
               <TableRow key={index}>
                 <TableCell>{card.customerName}</TableCell>
                 <TableCell>{card.transactionId}</TableCell>
+                <TableCell>{card.subscription_id}</TableCell>
+                <TableCell>{card.transferCode}</TableCell>
                 <TableCell>
                   {card.createdAt &&
                   typeof card.createdAt.seconds === "number" &&


### PR DESCRIPTION
This PR features the addition of subscription ID and transfer code columns to the print card table as requested.

![image](https://github.com/user-attachments/assets/24f106d8-026a-40b7-843c-e54c959e62f1)
