### PR TITLE
Card Portfolio Preview

### DIFF
--- a/components/DigitalCard.tsx
+++ b/components/DigitalCard.tsx
@@ -28,6 +28,7 @@ import {
   Edit2,
   Loader2Icon,
   Trash,
+  EyeIcon,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -364,17 +365,22 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
         </Link>
 
         <div className="flex flex-col justify-center absolute rounded-tr-[30px] rounded-br-[30px] top-1/2 -translate-y-1/2  items-center  z-10 pr-2 py-2 bg-neutral-950/80 backdrop-blur-sm">
-          {/* <Tooltip>
+          <Tooltip>
             <TooltipTrigger asChild>
-              <Link
-                href={`/site/${card.id}`}
-                className="px-3 py-3 2xl:py-2 hover:opacity-50 cursor-pointer"
-                prefetch
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <EyeIcon className="size-4 text-white drop-shadow-md" />
-              </Link>
+              {card.portfolioStatus
+                ? <Link
+                  href={`/site/${card.id}`}
+                  className="px-3 py-3 2xl:py-2 hover:opacity-50 cursor-pointer"
+                  prefetch
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <EyeIcon className="size-4 text-white drop-shadow-md" />
+                </Link>
+                : <span className="p-3 2xl:py-2 opacity-50">
+                  <EyeIcon className="size-4 text-white drop-shadow-md" />
+                </span>
+              }
             </TooltipTrigger>
             <TooltipPortal>
               <TooltipContent
@@ -385,7 +391,7 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
                 <TooltipArrow className="fill-black" />
               </TooltipContent>
             </TooltipPortal>
-          </Tooltip> */}
+          </Tooltip>
 
           {/* <Tooltip>
             <TooltipTrigger asChild>

--- a/components/DigitalCard.tsx
+++ b/components/DigitalCard.tsx
@@ -367,9 +367,9 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
         <div className="flex flex-col justify-center absolute rounded-tr-[30px] rounded-br-[30px] top-1/2 -translate-y-1/2  items-center  z-10 pr-2 py-2 bg-neutral-950/80 backdrop-blur-sm">
           <Tooltip>
             <TooltipTrigger asChild>
-              {card.portfolioStatus
-                ? <Link
-                  href={`/site/${card.id}`}
+              {card.portfolioStatus ? (
+                <Link
+                  href={`/site/${card.customUrl ? card.customUrl : card.id}`}
                   className="px-3 py-3 2xl:py-2 hover:opacity-50 cursor-pointer"
                   prefetch
                   target="_blank"
@@ -377,10 +377,11 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
                 >
                   <EyeIcon className="size-4 text-white drop-shadow-md" />
                 </Link>
-                : <span className="p-3 2xl:py-2 opacity-50">
+              ) : (
+                <span className="p-3 2xl:py-2 opacity-50">
                   <EyeIcon className="size-4 text-white drop-shadow-md" />
                 </span>
-              }
+              )}
             </TooltipTrigger>
             <TooltipPortal>
               <TooltipContent

--- a/lib/firebase/actions/card.action.ts
+++ b/lib/firebase/actions/card.action.ts
@@ -153,6 +153,7 @@ export const getCardById = async (
       console.log("Searching for card by custom URL...");
 
       const cardsCollection = collection(firebaseDb, "cards");
+
       const customUrlQuery = query(
         cardsCollection,
         where("customUrl", "==", input)

--- a/src/app/(publicSite)/site/[id]/_components/TemplateHandler.tsx
+++ b/src/app/(publicSite)/site/[id]/_components/TemplateHandler.tsx
@@ -13,9 +13,11 @@ import Template9 from "@/components/templates/Template9";
 import Template10 from "@/components/templates/Template10";
 import Template11 from "@/components/templates/Template11";
 import Template12 from "@/components/templates/Template12";
-import { Card } from "@/types/types";
+import { Card as cardType } from "@/types/types";
+import { Card, CardContent } from "@/components/ui/card";
+import Link from "next/link";
 
-const UserPage = ({ userData }: { userData: Card }) => {
+const UserPage = ({ userData }: { userData: cardType }) => {
   const renderTemplate = {
     template1: <Template1 {...userData} />,
     template2: <Template2 {...userData} />,
@@ -39,7 +41,30 @@ const UserPage = ({ userData }: { userData: Card }) => {
       {(userData as ChosenTemplateType).chosenTemplate in renderTemplate ? (
         renderTemplate[(userData as ChosenTemplateType).chosenTemplate]
       ) : (
-        <div>Invalid template</div>
+        <div className="flex flex-col justify-center min-h-screen p-4 md:p-8 lg:p-16 d">
+          {/* Main Content Container */}
+          <div className="container">
+            <div className="pl-0 md:pl-8 lg:pl-16">
+              {/* Title */}
+              <h1 className="text-[40px] md:text-[60px] lg:text-[96px] text-[#1FAE3A] font-medium italic leading-[1.5] mb-4">
+                Oops,
+              </h1>
+
+              {/* Description */}
+              <p className="text-[20px] md:text-[28px] lg:text-[36px] text-foreground font-bold leading-[1.5] max-w-[700px]">
+               Page template is not available.
+              </p>
+
+              {/* Button */}
+              <Link
+                href="/dashboard"
+                className="inline-block mt-8 bg-[#22A348] hover:bg-[#1B8A3A] text-white px-6 py-2.5 rounded-md transition-colors duration-200"
+              >
+                Back To Main
+              </Link>
+            </div>
+          </div>
+        </div>
       )}
     </main>
   );

--- a/src/app/(publicSite)/site/[id]/_components/TemplateHandler.tsx
+++ b/src/app/(publicSite)/site/[id]/_components/TemplateHandler.tsx
@@ -7,6 +7,12 @@ import Template3 from "@/components/templates/Template3";
 import Template4 from "@/components/templates/Template4";
 import Template5 from "@/components/templates/Template5";
 import Template6 from "@/components/templates/Template6";
+import Template7 from "@/components/templates/Template7";
+import Template8 from "@/components/templates/Template8";
+import Template9 from "@/components/templates/Template9";
+import Template10 from "@/components/templates/Template10";
+import Template11 from "@/components/templates/Template11";
+import Template12 from "@/components/templates/Template12";
 import { Card } from "@/types/types";
 
 const UserPage = ({ userData }: { userData: Card }) => {
@@ -17,6 +23,12 @@ const UserPage = ({ userData }: { userData: Card }) => {
     template4: <Template4 {...userData} />,
     template5: <Template5 {...userData} />,
     template6: <Template6 userData={userData} />,
+    template7: <Template7 {...userData} />,
+    template8: <Template8 {...userData} />,
+    template9: <Template9 {...userData} />,
+    template10: <Template10 {...userData} />,
+    template11: <Template11 {...userData} />,
+    template12: <Template12 {...userData} />,
   };
 
   interface ChosenTemplateType {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -18,7 +18,7 @@ export default function NotFound() {
 
           {/* Button */}
           <Link
-            href="/dashboard"
+            href="/"
             className="inline-block mt-8 bg-[#22A348] hover:bg-[#1B8A3A] text-white px-6 py-2.5 rounded-md transition-colors duration-200"
           >
             Back To Main

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -148,7 +148,7 @@ export interface Card extends Users {
   transferCode: string;
   expiryDate?: number;
   disabled?: boolean;
-  customUrl: string;
+  customUrl?: string;
   chosenPhysicalCard?: {
     id: string;
     name?: string;

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -154,6 +154,7 @@ export interface Card extends Users {
   };
   subscription_id?: string;
   createdAt: Timestamp | FieldValue;
+  portfolioStatus?: boolean;
 }
 
 export interface DeliveryAddress {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -148,6 +148,7 @@ export interface Card extends Users {
   transferCode: string;
   expiryDate?: number;
   disabled?: boolean;
+  customUrl: string;
   chosenPhysicalCard?: {
     id: string;
     name?: string;


### PR DESCRIPTION
This PR features the portfolio preview functionality for each card in the user card page

### Features
* Added preview button.

* Disabled preview button if `card.portfolioStatus` is falsey.
![Untitled](https://github.com/user-attachments/assets/2eb4996f-3a57-4eaf-833f-5bad3af1d788)

* Portfolio page can render 12 available templates.
![Untitled](https://github.com/user-attachments/assets/efed1b9a-5a39-4777-9b67-14a536e9f457)

**e.g. portfolio page**
![Untitled](https://github.com/user-attachments/assets/8e1ba6e4-51c5-45d7-92fd-7d04817b089f)

* Added fallback page for invalid template pages.
![Untitled](https://github.com/user-attachments/assets/467d95b6-6bfc-4e11-ade3-1a6785c877ce)

* Custom URL for portfolio pages.
![Untitled](https://github.com/user-attachments/assets/7603040b-4aae-46fe-9a3c-6293b3682674)
