### PR TITLE
Fix: landing cart continue shopping redirection

### DIFF
--- a/components/cart/Cart.tsx
+++ b/components/cart/Cart.tsx
@@ -154,9 +154,12 @@ export default function Cart() {
                 className="mt-4"
                 onClick={() => {
                   closeCart();
-                  if (window.location.pathname !== "/cards/card-shop") {
-                    router.push("/cards/card-shop");
-                  }
+
+                  const path = window.location.pathname;
+                  if (path === "/cards/card-shop" ||  path === "/card") return;
+                  
+                  const targetPath = user ? "/cards/card-shop" : "/card";
+                  router.push(targetPath);
                 }}
               >
                 Continue Shopping


### PR DESCRIPTION
This PR features a small fix to the "Continue Shopping" button redirection. If not logged in, the button will redirect to `/card` instead of `/cards/card-shop`.