### PR TITLE
Add Custom URL Validation

### DIFF
--- a/lib/firebase/actions/card.action.ts
+++ b/lib/firebase/actions/card.action.ts
@@ -290,9 +290,6 @@ export const addCustomUrl = async (
       throw new Error("Missing card ID");
     }
 
-    const rawCustomUrl = (customUrl ?? "").trim();
-    const formattedUrl = rawCustomUrl.toLowerCase().replace(/\s+/g, "-");
-
     const cardRef = doc(firebaseDb, "cards", rawCardId);
     const cardSnap = await getDoc(cardRef);
     if (!cardSnap.exists()) {
@@ -301,7 +298,7 @@ export const addCustomUrl = async (
 
     const cardData = cardSnap.data();
 
-    if (!formattedUrl) {
+    if (!customUrl) {
       await updateDoc(cardRef, {
         customUrl: deleteField(),
       });
@@ -309,7 +306,7 @@ export const addCustomUrl = async (
       return { success: true, message: "Custom URL removed successfully" };
     }
 
-    if (formattedUrl === rawCardId) {
+    if (customUrl === rawCardId) {
       throw new Error("Custom URL cannot be the same as the card ID");
     }
 
@@ -329,7 +326,7 @@ export const addCustomUrl = async (
     const existing = await getDocs(
       query(
         collection(firebaseDb, "cards"),
-        where("customUrl", "==", formattedUrl)
+        where("customUrl", "==", customUrl)
       )
     );
     if (!existing.empty) {
@@ -337,7 +334,7 @@ export const addCustomUrl = async (
     }
 
     await updateDoc(cardRef, {
-      customUrl: formattedUrl,
+      customUrl: customUrl,
       customUrlUpdatedAt: serverTimestamp(),
     });
 

--- a/lib/firebase/actions/card.action.ts
+++ b/lib/firebase/actions/card.action.ts
@@ -15,6 +15,7 @@ import {
   updateDoc,
   where,
   writeBatch,
+  deleteField,
 } from "firebase/firestore";
 import { firebaseDb } from "../firebase";
 import { toast } from "react-toastify";
@@ -279,20 +280,20 @@ export const updateCardById = async ({
   }
 };
 
-export const addCustomUrl = async (customUrl: string, cardId: string) => {
+export const addCustomUrl = async (
+  customUrl: string | undefined,
+  cardId: string | undefined
+) => {
   try {
-    if (!customUrl || !cardId) throw new Error("Missing parameters");
-
-    // Convert to lowercase & remove spaces for consistency
-    const formattedUrl = customUrl.trim().toLowerCase().replace(/\s+/g, "-");
-
-    // Prevent users from using a card ID as a custom URL
-    if (formattedUrl === cardId) {
-      throw new Error("Custom URL cannot be the same as the card ID");
+    const rawCardId = (cardId ?? "").trim();
+    if (!rawCardId) {
+      throw new Error("Missing card ID");
     }
 
-    // Check if the card exists
-    const cardRef = doc(firebaseDb, "cards", cardId);
+    const rawCustomUrl = (customUrl ?? "").trim();
+    const formattedUrl = rawCustomUrl.toLowerCase().replace(/\s+/g, "-");
+
+    const cardRef = doc(firebaseDb, "cards", rawCardId);
     const cardSnap = await getDoc(cardRef);
     if (!cardSnap.exists()) {
       throw new Error("Card not found");
@@ -300,45 +301,53 @@ export const addCustomUrl = async (customUrl: string, cardId: string) => {
 
     const cardData = cardSnap.data();
 
-    if (cardData?.customUrl && cardData.customUrlCreatedAt) {
-      const createdAt = cardData.customUrlCreatedAt.toDate();
+    if (!formattedUrl) {
+      await updateDoc(cardRef, {
+        customUrl: deleteField(),
+      });
+
+      return { success: true, message: "Custom URL removed successfully" };
+    }
+
+    if (formattedUrl === rawCardId) {
+      throw new Error("Custom URL cannot be the same as the card ID");
+    }
+
+    // Enforce 30-day limit
+    if (cardData?.customUrl && cardData.customUrlUpdatedAt) {
+      const createdAt = cardData.customUrlUpdatedAt.toDate();
       const now = new Date();
-      const timeDiff = now.getTime() - createdAt.getTime();
-      const daysElapsed = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
+      const daysElapsed = Math.floor((now.getTime() - createdAt.getTime()) / (1000 * 60 * 60 * 24));
       const daysRemaining = 30 - daysElapsed;
 
       if (daysRemaining > 0) {
-        throw new Error(
-          `Custom URL can only be changed after ${daysRemaining} days`
-        );
+        throw new Error(`Custom URL can only be changed after ${daysRemaining} days`);
       }
     }
 
-    // Check if the custom URL is already assigned to another card
-    const cardsCollectionRef = collection(firebaseDb, "cards");
-    const customUrlQuery = query(
-      cardsCollectionRef,
-      where("customUrl", "==", formattedUrl)
+    // Check if formatted URL is already used
+    const existing = await getDocs(
+      query(
+        collection(firebaseDb, "cards"),
+        where("customUrl", "==", formattedUrl)
+      )
     );
-    const querySnapshot = await getDocs(customUrlQuery);
-
-    if (!querySnapshot.empty) {
+    if (!existing.empty) {
       throw new Error("Custom URL already in use by another card");
     }
 
-    // Update the card document to store the custom URL and timestamp
     await updateDoc(cardRef, {
       customUrl: formattedUrl,
-      customUrlCreatedAt: serverTimestamp(), // Store the new timestamp
+      customUrlUpdatedAt: serverTimestamp(),
     });
 
     return { success: true, message: "Custom URL added successfully" };
   } catch (error) {
     console.error("Error adding custom URL:", error);
-
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    return { success: false, message: errorMessage };
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error",
+    };
   }
 };
 


### PR DESCRIPTION
This PR features the validation for the custom URL field in the multi-step form for each card portfolio. This uses an existing `addCustomUrl()` from `firebase/actions/card.action.ts` with slight modifications into it.

### Validations
- If custom URL is already in use.
![image](https://github.com/user-attachments/assets/7a9a3764-b34d-40f9-925a-86e1a6439b2c)

- Restrict custom URL updates within a 30-day limit.
![image](https://github.com/user-attachments/assets/14854432-e642-43c2-a285-d1dfd7aec21e)

### Modifications to `addCustomUrl()`
- Accepts empty string to `customUrl` parameter, this will clear the field. Timestamp will remain for the 30-day restriction.
- Renamed `customUrlCreatedAt` into `customUrlUpdatedAt` for better semantics.
- Updates to `customUrlUpdatedAt` only applies to **changing** not removing.
- Remove URL formatting.