### PR TITLE
Feature: Reordering Cards in User Card Page

### DIFF
--- a/components/DigitalCard.tsx
+++ b/components/DigitalCard.tsx
@@ -376,7 +376,7 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
           </div>
         </Link>
 
-        <div className="flex flex-col justify-center absolute rounded-tr-[30px] rounded-br-[30px] top-1/2 -translate-y-1/2  items-center  z-10 pr-2 py-2 bg-neutral-950/80 backdrop-blur-sm">
+        <div className="flex flex-col justify-center absolute rounded-tr-[30px] rounded-br-[30px] top-1/2 -translate-y-1/2  items-center pr-2 py-2 bg-neutral-950/80 backdrop-blur-sm">
           <Tooltip>
             <TooltipTrigger asChild>
               {card.portfolioStatus && !isCardDisabled ? (

--- a/lib/firebase/actions/user.action.ts
+++ b/lib/firebase/actions/user.action.ts
@@ -771,3 +771,38 @@ export const updateUserInfo = async ({
     throw new Error("Failed to update user info");
   }
 };
+
+export const getUserCardOrdering = async (userId: string): Promise<string[] | null> => {
+  try {
+    const userRef = doc(firebaseDb, "user-account", userId);
+    const docSnap = await getDoc(userRef);
+    if (docSnap.exists()) {
+      const data = docSnap.data();
+      return data.cardOrdering || null;
+    }
+    return null;
+  } catch (error) {
+    console.error("Error fetching cardOrdering:", error);
+    return null;
+  }
+};
+
+export const updateUserCardOrdering = async (
+  userId: string,
+  cardOrdering: string[]
+) => {
+  try {
+    const userRef = doc(collection(firebaseDb, "user-account"), userId);
+
+    await updateDoc(userRef, {
+      cardOrdering: cardOrdering,
+    });
+
+    console.log("Card ordering updated for user:", userId);
+    // toast.success("Card order saved.");
+  } catch (error: any) {
+    toast.error("Failed to save card order.");
+    console.error("Error updating cardOrdering:", error);
+    throw error;
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-alert-dialog": "^1.1.2",
@@ -113,6 +115,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "prettier": "prettier"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",

--- a/src/app/(secured)/(user)/(boarded)/cards/_components/SortableCard.tsx
+++ b/src/app/(secured)/(user)/(boarded)/cards/_components/SortableCard.tsx
@@ -1,0 +1,37 @@
+import DigitalCard from "@/components/DigitalCard";
+import { GripHorizontal } from "lucide-react";
+import { CSS } from "@dnd-kit/utilities";
+import { useSortable } from "@dnd-kit/sortable";
+
+export const SortableCard = ({ card, user, confirm }: any) => {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+    } = useSortable({ id: card.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            {...attributes}
+            className="w-full relative"
+        >
+            <div className="relative w-full">
+                <DigitalCard user={user} confirm={confirm} card={card} />
+                <div
+                    className="absolute top-1 w-full flex justify-center cursor-pointer"
+                >
+                    <GripHorizontal {...listeners} className="size-12 text-white lg:size-8 opacity-50 hover:opacity-100 transition-opacity duration-150" />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/app/(secured)/(user)/(boarded)/cards/_components/cards.tsx
+++ b/src/app/(secured)/(user)/(boarded)/cards/_components/cards.tsx
@@ -1,31 +1,38 @@
 "use client";
 
-import React, { useState } from "react";
-import DigitalCard from "@/components/DigitalCard";
+import React, { useState, useEffect } from "react";
+import { SortableCard } from "./SortableCard";
 import Link from "next/link";
 import { useUserContext } from "@/providers/user-provider";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getCardsByOwner,
   transferCardOwnershipUsingCode,
 } from "@/lib/firebase/actions/card.action";
+import { updateUserCardOrdering, getUserCardOrdering } from "@/lib/firebase/actions/user.action";
 import Loading from "@/src/app/loading";
 import { useConfirm } from "@/hooks/useConfirm";
-// import { QrCode, ShoppingBag } from "lucide-react";
-// import { ShoppingBag } from "lucide-react";
-
-// import QrCodeModal from "@/components/qrcode/qrcode-modal";
 import * as Dialog from "@radix-ui/react-dialog";
 import { firebaseAuth } from "@/lib/firebase/firebase";
 import { toast } from "react-toastify";
-import { useQueryClient } from "@tanstack/react-query";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-// import { useRouter } from "next/navigation";
+import { Card } from "@/types/types";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCorners,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  rectSortingStrategy,
+} from "@dnd-kit/sortable";
 
 const Cards = () => {
-  // const router = useRouter();
   const [ConfirmDialog, confirm] = useConfirm(
     "Are you sure ?",
     "You are about to delete this card"
@@ -36,52 +43,91 @@ const Cards = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [transferCode, setTransferCode] = useState("");
   const [loadTransferCode, setLoadTransferCode] = useState(false);
+  const [orderedCards, setOrderedCards] = useState<Card[]>([]);
   let ctxTimeout: any = null;
+
+  // Sort cards based on the cardOrdering field from the user-account document
+  const sortCards = async (
+    cards: Partial<Card>[],
+    uid: string
+  ): Promise<Card[]> => {
+    const ordering = await getUserCardOrdering(uid);
+
+    if (!ordering) {
+      return cards.filter((c): c is Card => !!c.id && !!c.owner); // return in original order (typed safely)
+    }
+
+    const cardMap = new Map(cards.map(card => [card.id, card]));
+    const sorted = ordering
+      .map(id => cardMap.get(id))
+      .filter((card): card is Card => !!card?.id && !!card?.owner);
+
+    const unordered = cards.filter(
+      (c): c is Card => !!c.id && !!c.owner && !ordering.includes(c.id)
+    );
+
+    return [...sorted, ...unordered];
+  };
 
   const { data: cards, status } = useQuery({
     enabled: !!user?.uid,
     queryKey: ["cards", user?.uid],
-    queryFn: () => getCardsByOwner(user?.uid!),
+    queryFn: async () => {
+      if (!user?.uid) throw new Error("User UID is undefined");
+
+      const cards = await getCardsByOwner(user.uid);
+      const sortedCards = await sortCards(cards, user.uid);
+      return sortedCards;
+    },
     staleTime: 1000 * 60 * 5,
   });
 
-  const handleAddCard = () => {
-    setIsDialogOpen(true);
+  useEffect(() => {
+    if (cards) setOrderedCards(cards);
+  }, [cards]);
+
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  const handleDragEnd = async (event: any) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = orderedCards.findIndex((c) => c.id === active.id);
+    const newIndex = orderedCards.findIndex((c) => c.id === over.id);
+    const newOrdering = arrayMove(orderedCards, oldIndex, newIndex);
+    setOrderedCards(newOrdering);
+
+    if (user?.uid) {
+      const newCardOrder: string[] = newOrdering
+        .map(card => card.id)
+        .filter((id): id is string => !!id);
+      await updateUserCardOrdering(user.uid, newCardOrder);
+    }
   };
 
   const handleTransferOwnership = async () => {
     const cleanTranferCode = transferCode.trim();
-
     if (!cleanTranferCode) {
       toast.error("Please enter a transfer code.");
       return;
     }
-
     const currentUser = firebaseAuth.currentUser;
     if (!currentUser) {
       toast.error("You must be logged in to transfer a card.");
       return;
     }
-
     setLoadTransferCode(true);
     const success = await transferCardOwnershipUsingCode(
       cleanTranferCode,
       currentUser.uid
     );
-
     if (success) {
       setIsDialogOpen(false);
       setTransferCode("");
       queryClient.invalidateQueries({ queryKey: ["cards", currentUser.uid] });
     }
-
-    if (ctxTimeout) {
-      clearTimeout(ctxTimeout);
-    }
-
-    ctxTimeout = setTimeout(() => {
-      setLoadTransferCode(false);
-    }, 1500);
+    if (ctxTimeout) clearTimeout(ctxTimeout);
+    ctxTimeout = setTimeout(() => setLoadTransferCode(false), 1500);
   };
 
   if (status === "pending") return <Loading />;
@@ -89,45 +135,53 @@ const Cards = () => {
   return (
     <>
       <ConfirmDialog />
-      <div className="px-4 flex flex-col min-h-full md:px-16 py-8">
-        <div className="flex items-center justify-between">
+      <div className="grid grid-cols-1 grid-rows-[auto_1fr] min-h-screen py-4 md:py-8 gap-2 lg:gap-4">
+        <div className="flex items-center justify-between px-4 md:px-16">
           <h1 className="text-xl md:text-2xl font-semibold">My Cards</h1>
-
           <div className="flex gap-x-2">
-            <Button variant={"outline"} onClick={handleAddCard}>
+            <Button variant="outline" onClick={() => setIsDialogOpen(true)}>
               Add Card
             </Button>
-            <Link href={"/cards/card-shop"}>
-              <Button variant={"green"}>Buy a Card</Button>
+            <Link href="/cards/card-shop">
+              <Button variant="green">Buy a Card</Button>
             </Link>
           </div>
         </div>
 
-        <TooltipProvider>
-          <div className="grid justify-center grid-cols-[repeat(auto-fill,minmax(18rem,24rem))] justify-items-center xl:justify-start xl:grid-cols-[repeat(auto-fill,minmax(18rem,1fr))] gap-4 mt-8">
-            {cards && cards.length > 0 ? (
-              cards.map((card) => (
-                <DigitalCard
-                  user={user}
-                  confirm={confirm}
-                  key={card.id}
-                  card={card}
-                />
-              ))
-            ) : (
-              <div className="col-span-full flex flex-col items-center justify-center min-h-[60vh]">
-                <div className="flex flex-col items-center">
-                  <h2 className="text-2xl md:text-3xl font-bold text-greenTitle mb-4">
-                    No Cards Yet
-                  </h2>
-                  <p className="text-base md:text-lg text-grayDescription text-center mb-8 max-w-md">
-                    Create your first digital business card to get started!
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-        </TooltipProvider>
+        <div className="px-4 md:px-14">
+          <TooltipProvider>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCorners}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={orderedCards.filter(c => c.id !== undefined).map(c => c.id as string)}
+                strategy={rectSortingStrategy}
+              >
+                {orderedCards.length > 0 ? (
+                  <div className="grid justify-center grid-cols-[repeat(auto-fill,minmax(18rem,24rem))] justify-items-center xl:justify-start xl:grid-cols-[repeat(auto-fill,minmax(18rem,1fr))] gap-4 md:px-2 outline-2 outline-red-400">
+                    {orderedCards.map((card) => (
+                      <SortableCard key={card.id} card={card} user={user} confirm={confirm} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="col-span-full flex flex-col items-center justify-center min-h-[60vh]">
+                    <div className="flex flex-col items-center">
+                      <h2 className="text-2xl md:text-3xl font-bold text-greenTitle mb-4">
+                        No Cards Yet
+                      </h2>
+                      <p className="text-base md:text-lg text-grayDescription text-center mb-8 max-w-md">
+                        Create your first digital business card to get started!
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </SortableContext>
+            </DndContext>
+          </TooltipProvider>
+        </div>
+
         <Dialog.Root open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <Dialog.Portal>
             <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
@@ -153,7 +207,8 @@ const Cards = () => {
                     </Dialog.Close>
                   )}
                   <button
-                    className={`${loadTransferCode && "opacity-75"} bg-green-500 px-4 py-2 text-white rounded flex items-center`}
+                    className={`$${loadTransferCode && "opacity-75"
+                      } bg-green-500 px-4 py-2 text-white rounded flex items-center`}
                     onClick={handleTransferOwnership}
                     disabled={loadTransferCode}
                   >

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -123,6 +123,7 @@ export interface ExtendedUserInterface extends Users {
   role: string;
   onboarding: boolean;
   deliveryAddresses?: DeliveryAddress[];
+  cardOrdering?: string[];
 }
 
 export type UserState = ExtendedUserInterface | null;


### PR DESCRIPTION
This PR introduces a new functionality in the user card page. Users are now allowed to reorder the cards. This new feature make use of the [`dnd kit`](https://dndkit.com/) library for the drag-and-drop mechanism and new server actions for handling the ordering persistence in the DB.

### Major Updates
* Drag-and-Drop Functionality
![20250620_181240](https://github.com/user-attachments/assets/fdbfa6b3-d7b5-44cc-8d87-44cea6976d40)

* Persistent Ordering thru Server Actions (`updateUserCardOrdering`, `getUserCardOrdering`)
![image](https://github.com/user-attachments/assets/382fced0-f119-406b-9d87-28225b812956)

#### Notes
* Please do `npm install` for the [`dnd kit`](https://dndkit.com/) library.
* So far, the logics can handle adding and transferring of cards.