### PR TITLE
Fix: card thumbnails redirect to "/site" instead of "/card"

### DIFF
--- a/components/DigitalCard.tsx
+++ b/components/DigitalCard.tsx
@@ -372,7 +372,7 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
         >
           <Tooltip>
             <TooltipTrigger asChild>
-              {card.portfolioStatus && !isCardDisabled ? (
+              {!isCardExpired(card.expiryDate) && card.portfolioStatus && !isCardDisabled ? (
                 <Link
                   href={`/site/${card.customUrl ? card.customUrl : card.id}`}
                   className="px-2 py-2 2xl:py-2 hover:opacity-50 cursor-pointer border dark:border-accent border-gray-300 rounded-md"
@@ -522,8 +522,9 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
             <div className="flex-1 py-3 px-4 relative">{CardInfo}</div>
           ) : (
             <Link
-              href={isCardExpired(card.expiryDate) ? "#" : `/cards/${card.id}`}
+              href={isCardExpired(card.expiryDate) || !card.portfolioStatus || isCardDisabled ? "" : (`/site/${card.customUrl ? card.customUrl : card.id}`)}
               prefetch
+              target="_blank"
               className="flex-1 py-3 px-4 relative"
               onClick={(e) => {
                 if (isCardExpired(card.expiryDate)) {

--- a/components/DigitalCard.tsx
+++ b/components/DigitalCard.tsx
@@ -445,11 +445,10 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
               <Tooltip key={index}>
                 <TooltipTrigger asChild>
                   <span
-                    className={`px-2 py-2 2xl:py-2 border dark:border-accent border-gray-300 rounded-md ${
-                      isDisabledState
+                    className={`px-2 py-2 2xl:py-2 border dark:border-accent border-gray-300 rounded-md ${isDisabledState
                         ? "opacity-30 cursor-not-allowed"
                         : "hover:opacity-50 cursor-pointer"
-                    }`}
+                      }`}
                     onClick={!isDisabledState ? item.fn : undefined}
                   >
                     <item.icon className="size-4 dark:text-white drop-shadow-md" />
@@ -522,7 +521,11 @@ const DigitalCard = ({ card, confirm, user }: Prop) => {
             <div className="flex-1 py-3 px-4 relative">{CardInfo}</div>
           ) : (
             <Link
-              href={isCardExpired(card.expiryDate) || !card.portfolioStatus || isCardDisabled ? "" : (`/site/${card.customUrl ? card.customUrl : card.id}`)}
+              href={
+                isCardExpired(card.expiryDate) || !card.portfolioStatus || isCardDisabled
+                  ? ""
+                  : (`/site/${card.customUrl ? card.customUrl : card.id}`)
+              }
               prefetch
               target="_blank"
               className="flex-1 py-3 px-4 relative"


### PR DESCRIPTION
This PR includes fix for the card thumbnail link and update the conditionals of the link (consider the 3 criteria).

<img width="779" height="199" alt="image" src="https://github.com/user-attachments/assets/65202765-289d-481f-a695-e4030b558e50" />
