### PR TITLE
Fix multiple companies optionality

### DIFF
--- a/components/forms/multi-step-form-update.tsx
+++ b/components/forms/multi-step-form-update.tsx
@@ -149,6 +149,9 @@ const MultiStepFormUpdate = ({
     }
   }, [companies.length]);
 
+  useEffect(() => {
+    methods.setValue("companies", companies);
+  }, [companies]);
 
   const [servicePhotos, setServicePhotos] = useState<Photo[]>([]);
   const [serviceImageUrls, setServiceImageUrls] = useState<string[]>(
@@ -248,6 +251,7 @@ const MultiStepFormUpdate = ({
       coverPhotoUrl: userData.coverPhotoUrl || "",
       profilePictureUrl: userData.profilePictureUrl || "",
       position: userData.position || "",
+      companies: userData.companies || [],
       company: userData.company || "",
       companyBackground: userData.companyBackground || "",
       serviceDescription: userData.serviceDescription || "",

--- a/lib/zod-schema.ts
+++ b/lib/zod-schema.ts
@@ -12,13 +12,11 @@ const refinePhoneNumber = (phoneNumber: string) => {
 
 export const companySchema = z.object({
   company: z
-    .string({ required_error: 'Company name is required.' })
-    .min(2, { message: 'Company name must be at least 2 characters long.' })
+    .string()
     .optional(),
 
   position: z
     .string()
-    .min(2, { message: 'Position must be at least 2 characters long.' })
     .optional(),
 
   companyBackground: z


### PR DESCRIPTION
This PR includes a fix to companies form by removing the `.min()` method in the zod schema to accept empty string fields, hence its optionality.