### PR TITLE
Fix: correct misaligned word 'optional'

### DIFF
--- a/components/forms/multi-step-form-update.tsx
+++ b/components/forms/multi-step-form-update.tsx
@@ -982,7 +982,7 @@ const MultiStepFormUpdate = ({
                 <div className="space-y-8">
                   <div>
                     <h2 className="text-lg font-semibold mb-2">
-                      Custom URL <sup className="font-normal">(optional)</sup>
+                      Custom URL (optional)
                     </h2>
 
                     <FormField


### PR DESCRIPTION
This PR includes a simple fix to the misaligned word "optional" in the custom URL label.

**Before:**
<img width="390" height="63" alt="Untitled" src="https://github.com/user-attachments/assets/9f41a0d7-7e47-4ab4-b894-6a8d194e0f72" />

**Now:**
<img width="398" height="141" alt="image" src="https://github.com/user-attachments/assets/27806de9-ba7d-4439-a061-5c45ac824905" />
